### PR TITLE
Added handlers to call onComplete and stop chromedriver cleanly when …

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -54,6 +54,10 @@ export default class ChromeDriverLauncher {
         if (typeof this.outputDir === 'string') {
             this._redirectLogStream()
         }
+
+        process.on('exit', this.onComplete)
+        process.on('SIGINT', this.onComplete)
+        process.on('uncaughtException', this.onComplete)
     }
 
     onComplete() {


### PR DESCRIPTION
…the process is terminated via WebdriverIO SevereServiceError. Fixes #53.

I've verified that, when the SevereServiceError is thrown from another service, chromedriver now terminates cleanly.  I wasn't sure how to start writing tests for verifying that `process.on('exit', ...)` triggers the call to onComplete, but all existing tests are passing.

Hoping we can merge these changes in.  If it helps, they did a similar thing with the @wdio/selenium-standalone service to ensure it stops the selenium server cleanly when another service throws a SevereServiceError.