### PR TITLE
Added ability to specify customChromeDriverLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,6 @@ Type: `string`
 ### chromedriverCustomPath
 To use a custome chromedriver different than the one installed through "chromedriver npm module", provide the path. 
 
-<<<<<<< HEAD
 Example: `/path/to/chromedriver` (Linux / MacOS), `./chromedriver.exe` or `d:/driver/chromedriver.exe` (Windows)
-=======
-Example: `./chromedriver.exe or d:/driver/chromedriver.exe`
->>>>>>> 97cab5cc0196adff5a29ea0841ebc309db1315b5
 
 Type: `string`
-
-
-----
-
-For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Type: `string`
 ### chromedriverCustomPath
 To use a custome chromedriver different than the one installed through "chromedriver npm module", provide the path. 
 
-Example: `.chromedriver.exe or d:/driver/chromedriver.exe`
+Example: `/path/to/chromedriver` (Linux / MacOS), `./chromedriver.exe` or `d:/driver/chromedriver.exe` (Windows)
 
 Type: `string`
 

--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ Example: `/path/to/chromedriver` (Linux / MacOS), `./chromedriver.exe` or `d:/dr
 
 Type: `string`
 
-For more information on WebdriverIO see the [homepage](http://webdriver.io).
+For more information on WebdriverIO see the [homepage](https://webdriver.io).

--- a/README.md
+++ b/README.md
@@ -117,3 +117,5 @@ To use a custome chromedriver different than the one installed through "chromedr
 Example: `/path/to/chromedriver` (Linux / MacOS), `./chromedriver.exe` or `d:/driver/chromedriver.exe` (Windows)
 
 Type: `string`
+
+For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Example: `wdio-chromedriver.log`
 
 Type: `string`
 
+### chromedriverCustomPath
+To use a custome chromedriver different than the one installed through "chromedriver npm module", provide the path. 
+
+Example: `.chromedriver.exe or d:/driver/chromedriver.exe`
+
+Type: `string`
+
+
 ----
 
 For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process'
 import fs from 'fs-extra'
-
+import path from 'path'
 import split2 from 'split2'
 import { path as chromedriverPath } from 'chromedriver'
 import logger from '@wdio/logger'
@@ -36,6 +36,7 @@ export default class ChromeDriverLauncher {
         this.logFileName = options.logFileName || DEFAULT_LOG_FILENAME
         this.capabilities = capabilities
         this.args = options.args || []
+        this.chromedriverCustomPath = options.chromedriverCustomPath ? path.resolve(options.chromedriverCustomPath) : chromedriverPath
     }
 
     async onPrepare() {
@@ -57,7 +58,7 @@ export default class ChromeDriverLauncher {
          */
         this._mapCapabilities()
 
-        let command = chromedriverPath
+        let command = this.chromedriverCustomPath
         log.info(`Start Chromedriver (${command}) with args ${this.args.join(' ')}`)
         if (!fs.existsSync(command)) {
             log.warn('Could not find chromedriver in default path: ', command)

--- a/tests/launcher.test.js
+++ b/tests/launcher.test.js
@@ -380,7 +380,7 @@ describe('ChromeDriverLauncher launcher', () => {
             expect(Launcher.chromedriverCustomPath).toEqual(path.resolve(options.chromedriverCustomPath))
         })
 
-        test('should select default chromedriver path "./chromedriver.exe"', async () => {
+        test('should select default chromedriver path if no custome path provided"', async () => {
             options.chromedriverCustomPath = undefined
             const Launcher = new ChromeDriverLauncher(options, capabilities, config)
             Launcher._redirectLogStream = jest.fn()        

--- a/tests/launcher.test.js
+++ b/tests/launcher.test.js
@@ -389,5 +389,3 @@ describe('ChromeDriverLauncher launcher', () => {
         })
     })
 })
-
-

--- a/tests/launcher.test.js
+++ b/tests/launcher.test.js
@@ -354,4 +354,40 @@ describe('ChromeDriverLauncher launcher', () => {
             expect(Launcher.process.stderr.pipe).toBeCalled()
         })
     })
+
+    describe('custom chromedriver Path', () => {
+        test('should select custom chromedriver path "chromedriver.exe"', async () => {
+            options.chromedriverCustomPath = 'chromedriver.exe'
+            const Launcher = new ChromeDriverLauncher(options, capabilities, config)
+            Launcher._redirectLogStream = jest.fn()        
+            await Launcher.onPrepare()        
+            expect(Launcher.chromedriverCustomPath).toEqual(path.resolve(options.chromedriverCustomPath))
+        })
+
+        test('should select custom chromedriver path "c:\\chromedriver.exe"', async () => {
+            options.chromedriverCustomPath = 'c:\\chromedriver.exe'
+            const Launcher = new ChromeDriverLauncher(options, capabilities, config)
+            Launcher._redirectLogStream = jest.fn()        
+            await Launcher.onPrepare()        
+            expect(Launcher.chromedriverCustomPath).toEqual(path.resolve(options.chromedriverCustomPath))
+        })
+
+        test('should select custom chromedriver path "./chromedriver.exe"', async () => {
+            options.chromedriverCustomPath = './chromedriver.exe'
+            const Launcher = new ChromeDriverLauncher(options, capabilities, config)
+            Launcher._redirectLogStream = jest.fn()        
+            await Launcher.onPrepare()        
+            expect(Launcher.chromedriverCustomPath).toEqual(path.resolve(options.chromedriverCustomPath))
+        })
+
+        test('should select default chromedriver path "./chromedriver.exe"', async () => {
+            options.chromedriverCustomPath = undefined
+            const Launcher = new ChromeDriverLauncher(options, capabilities, config)
+            Launcher._redirectLogStream = jest.fn()        
+            await Launcher.onPrepare()        
+            expect(Launcher.chromedriverCustomPath).not.toBeUndefined
+        })
+    })
 })
+
+


### PR DESCRIPTION
This allows to run electron application testing using chrome driver service by pointing to the chrome driver installed using "npm install electron-chromedriver"