### PR TITLE
add chromedriver to optional peerdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "@wdio/types": "^7.0.0"
   },
   "peerDependenciesMeta": {
+    "chromedriver": {
+      "optional": true
+    },
     "@wdio/types": {
       "optional": true
     }


### PR DESCRIPTION
Thanks to https://github.com/webdriverio-community/wdio-chromedriver-service/pull/64, `chromedriver` is now fully optional.  Adding the optional flag should squash the package manager warning about missing peerdeps.