### PR TITLE
fix(doc): updated readme.md file with correct WDIO installation page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install chromedriver --save-dev
 npm install chromedriver@104 --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
+Instructions on how to install `WebdriverIO` can be found [here.](https://webdriver.io/docs/gettingstarted)
 
 ## Configuration
 


### PR DESCRIPTION
updated readme.md file with correct WDIO installation page URL. that is https://webdriver.io/docs/gettingstarted.

<img width="726" alt="Screen Shot 2022-12-16 at 1 10 04 PM" src="https://user-images.githubusercontent.com/8421048/208161855-087cd5fe-4c19-4781-8beb-f9459c91b5ab.png">
